### PR TITLE
Remove New prefix from command function name

### DIFF
--- a/cmd/lift/main.go
+++ b/cmd/lift/main.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	rootCmd := commands.NewRootCommand()
+	rootCmd := commands.RootCommand()
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/pkg/commands/platform.go
+++ b/pkg/commands/platform.go
@@ -6,7 +6,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewPlatformCommand() *cobra.Command {
+func PlatformCommand() *cobra.Command {
 	platformCmd := &cobra.Command{
 		Use:   "platform",
 		Short: "Platform commands",
@@ -16,6 +16,6 @@ func NewPlatformCommand() *cobra.Command {
 			os.Exit(1)
 		},
 	}
-	platformCmd.AddCommand(NewPlatformListCommand())
+	platformCmd.AddCommand(PlatformListCommand())
 	return platformCmd
 }

--- a/pkg/commands/platform_list.go
+++ b/pkg/commands/platform_list.go
@@ -7,7 +7,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewPlatformListCommand() *cobra.Command {
+func PlatformListCommand() *cobra.Command {
 	listCmd := &cobra.Command{
 		Use:   "list",
 		Short: "Platform list",

--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -4,12 +4,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func NewRootCommand() *cobra.Command {
+func RootCommand() *cobra.Command {
 	rootCmd := &cobra.Command{
 		Use:   "lift",
 		Short: "multi cloud code generation tool",
 		Long:  `lift is a tool for enriching your application so it can be deployed to multiple cloud platforms with minimal effort.`,
 	}
-	rootCmd.AddCommand(NewPlatformCommand())
+	rootCmd.AddCommand(PlatformCommand())
 	return rootCmd
 }


### PR DESCRIPTION
prefixing cobra command function names with `New` (IMO) reads awkwardly, for example reading `NewPlatformCommand`, to me reads like this function would be creating a command that makes a new platform, which it doesn't. on the flip side its "creating" something for the cli framework.

this is solely a naming suggestion given the above observation, nothing technically wrong here

while i do like the compacting into function, i think between a `New` prefix and the generated `var` style in for example https://github.com/cloudlift/lift/blob/b98dc2ce7e20890762db3016583d67c2a77409fc/cmd/list.go#L9 i think id likely go for the generated approach, possibly compacting that down into `init`