### PR TITLE
Test against Go 1.13

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -173,6 +173,7 @@ issues:
       linters:
         - errcheck
         - maligned
+        - funlen
 
   # Independently from option `exclude` we use default exclude patterns,
   # it can be disabled by this option. To list all
@@ -187,4 +188,4 @@ issues:
   max-same-issues: 0
 
 service:
-  golangci-lint-version: 1.17.x # use the fixed version to not introduce new linters unexpectedl
+  golangci-lint-version: 1.18.x # use the fixed version to not introduce new linters unexpectedl

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ jobs:
   pool:
     vmImage: $(imageName)
   variables:
-    GOROOT: '/opt/hostedtoolcache/go/1.12.6/x64' # Go installation path
+    GOROOT: '/opt/hostedtoolcache/go/1.13/x64' # Go installation path
     GOBIN:  '$(GOPATH)/bin' # Go binaries path
     GOPATH: '$(system.defaultWorkingDirectory)/gopath' # Go workspace path
     modulePath: '$(build.repository.name)' # Path to the module's code
@@ -23,7 +23,7 @@ jobs:
   steps:
   - task: GoTool@0
     inputs:
-      version: 1.12.6
+      version: 1.13
       goPath:  '$(GOPATH)'
       goBin: '$(GOBIN)'
 
@@ -41,7 +41,7 @@ jobs:
     inputs:
       targetType: filePath
       filePath: ./hack/install-linters.sh
-      arguments: v1.17.1 #Fix version of linters to avoid unexpected failures
+      arguments: v1.18.0 #Fix version of linters to avoid unexpected failures
     displayName: Install golangci-lint tool
 
   - bash: |

--- a/hack/install-linters.sh
+++ b/hack/install-linters.sh
@@ -30,7 +30,7 @@ parse_args() {
     esac
   done
   shift $((OPTIND - 1))
-  TAG=$1
+  TAG=${1:-v1.18.0}
 }
 # this function wraps all the destructive operations
 # if a curl|bash cuts off the end of the script due to

--- a/pkg/initializr/initializr.go
+++ b/pkg/initializr/initializr.go
@@ -112,10 +112,7 @@ func unpack(zipContents []byte, targetPath string) error {
 		}
 		defer zippedFile.Close()
 
-		extractedFilePath := filepath.Join(
-			targetPath,
-			file.Name,
-		)
+		extractedFilePath := filepath.Join(targetPath, file.Name)
 
 		// Extract the item (or create directory)
 		if file.FileInfo().IsDir() {


### PR DESCRIPTION
update linters to 1.18
move statement in `unpack()` to a single line to avoid `funlen` linting error